### PR TITLE
Fix stdin read without period.

### DIFF
--- a/src/cronoutils.c
+++ b/src/cronoutils.c
@@ -170,7 +170,7 @@ new_log_file(const char *template, const char *linkname, mode_t linktype, const 
 }
 
 int
-ready_to_read(int fd, int seconds_remaining)
+ready_to_read(int fd, time_t seconds_remaining)
 {
     fd_set set;
     FD_ZERO(&set); /* clear the set */

--- a/src/cronoutils.h
+++ b/src/cronoutils.h
@@ -171,7 +171,7 @@ int		new_log_file(const char *template, const char *linkname,
 			     PERIODICITY periodicity, int period_multiple, int period_delay,
 			     char *pfilename, size_t pfilename_len,
 			     time_t time_now, time_t *pnext_period);
-int		ready_to_read(int fd, int seconds_remaining);
+int		ready_to_read(int fd, time_t seconds_remaining);
 void		create_subdirs(char *);
 void		create_link(char *, const char *, mode_t, const char *);
 PERIODICITY	determine_periodicity(char *);


### PR DESCRIPTION
Cronolog failed to start on 64-bit systems when run with template without period:
$ cronolog /tmp/out
select: Invalid argument

Already fixed in https://github.com/WayneD/cronolog/commit/1867e577c4a8c62d3cb956345590b7ae2d236fc9